### PR TITLE
avoid pip upgrade error

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ To get up and running with this project:
     ```shell
     python3 -m venv venv
     source venv/bin/activate
+    ./venv/bin/python3 -m pip install --upgrade pip
     python3 -m pip install -r requirements.txt
     source venv/bin/activate
     ```


### PR DESCRIPTION
I'm consistently facing this even after upgrading my local python installation's pip. It's the same issue across my work and personal macbooks. 