### PR TITLE
Align versions of dbt-core and dbt-duckdb

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,15 +26,15 @@ The raw data consists of customers, orders, and payments, with the following ent
 **Mach Speed: No explanation needed**
 
 ```shell
-python3 -m venv venv # create a virtual environment
-source venv/bin/activate # actitvate the virtual environment
-./venv/bin/python3 -m pip install --upgrade pip # upgrade pip to avoid installation errors
-python3 -m pip install -r requirements.txt # install all dependencies
-source venv/bin/activate # reactivate the virtual environment
-dbt build # load raw data into database, create tables/views in proper order, test data
-./D select 42 as answer from customers limit 1; # verify dbt worked with ad hoc query
-dbt docs generate # generate docs for this project
-dbt docs serve # serve docs for this project in your local browser
+python3 -m venv venv
+source venv/bin/activate
+venv/bin/python3 -m pip install --upgrade pip
+python3 -m pip install -r requirements.txt
+source venv/bin/activate
+dbt build
+./D select 42 as answer from customers limit 1;
+dbt docs generate
+dbt docs serve
 ```
 
 Prerequisities: Python >= 3.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
-dbt-duckdb == 1.1.1
-git+https://github.com/dbt-labs/dbt-core.git@experiment/local-profiles#egg=dbt-core&subdirectory=core
-git+https://github.com/dbt-labs/dbt-core.git@experiment/local-profiles#egg=dbt-postgres&subdirectory=plugins/postgres
+duckdb==0.3.4
+git+https://github.com/dbeatty10/dbt-duckdb.git@dbeatty_bump_dbt_core_minor_version#egg=dbt-duckdb
+git+https://github.com/dbt-labs/dbt-core.git@experiment/local-profiles-1.1.1#egg=dbt-core&subdirectory=core
+git+https://github.com/dbt-labs/dbt-core.git@experiment/local-profiles-1.1.1#egg=dbt-postgres&subdirectory=plugins/postgres


### PR DESCRIPTION
## Overview
Goal: use the maximal versions of dbt-core, dbt-duckdb, and duckdb possible

## Details
- Created a custom branch of dbt-core 1.1.1 to prioritize `profiles.yml` in the current working directory over `~/.dbt`
- Needed to create a customized branch of dbt-duckdb to work with dbt-core 1.1.1.
- duckdb==0.3.4 was the latest version that worked (recently released [0.4.0](https://pypi.org/project/duckdb/0.4.0/) gave errors)

## Erorr for duckdb 0.4.0
```
21:55:03  Database error while running on-run-start
21:55:03  Encountered an error:
Runtime Error
  TransactionContext Error: cannot commit - no transaction is active
```