### PR TITLE
Unpin duckdb package

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
-duckdb==0.3.4
 duckcli==0.0.1
-git+https://github.com/dbeatty10/dbt-duckdb.git@dbeatty_bump_dbt_core_minor_version#egg=dbt-duckdb
+git+https://github.com/jwills/dbt-duckdb.git@26f88f76c5841af26777d9b7571756968f1d72dc#egg=dbt-duckdb
 git+https://github.com/dbt-labs/dbt-core.git@experiment/local-profiles-1.1.1#egg=dbt-core&subdirectory=core
 git+https://github.com/dbt-labs/dbt-core.git@experiment/local-profiles-1.1.1#egg=dbt-postgres&subdirectory=plugins/postgres

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,9 @@
+# The only version that works currently
 duckcli==0.0.1
+
+# Replace with dbt-duckdb>=1.1.2,<1.2 when possible
 git+https://github.com/jwills/dbt-duckdb.git@26f88f76c5841af26777d9b7571756968f1d72dc#egg=dbt-duckdb
+
+# Look for `profiles.yml` in the current working directory to avoid needing to `export DBT_PROFILES_DIR=.`
 git+https://github.com/dbt-labs/dbt-core.git@experiment/local-profiles-1.1.1#egg=dbt-core&subdirectory=core
 git+https://github.com/dbt-labs/dbt-core.git@experiment/local-profiles-1.1.1#egg=dbt-postgres&subdirectory=plugins/postgres


### PR DESCRIPTION
Two things:
- Unpin the version of duckdb (to allow for whatever range dbt-duckdb allows) 
- Explain each dependency in `requirements.txt`