### PR TITLE
Switch to adapter that's on PyPI

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
 # The only version that works currently
 duckcli==0.0.1
 
-# Replace with dbt-duckdb>=1.1.2,<1.2 when possible
-git+https://github.com/jwills/dbt-duckdb.git@26f88f76c5841af26777d9b7571756968f1d72dc#egg=dbt-duckdb
+# Database adapter
+dbt-duckdb>=1.1.2,<1.2.0
 
 # Look for `profiles.yml` in the current working directory to avoid needing to `export DBT_PROFILES_DIR=.`
 git+https://github.com/dbt-labs/dbt-core.git@experiment/local-profiles-1.1.1#egg=dbt-core&subdirectory=core


### PR DESCRIPTION
## Why wasn't it using PyPI before?
The most recent version on PyPI was permissive on version ranges. This caused issues once duckdb 0.4.0 was released.