### PR TITLE
Use a consistent reference to Python location

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ git clone https://github.com/dbt-labs/jaffle_shop_duckdb.git
 cd jaffle_shop_duckdb
 python3 -m venv venv
 source venv/bin/activate
-venv/bin/python3 -m pip install --upgrade pip
+python3 -m pip install --upgrade pip
 python3 -m pip install -r requirements.txt
 source venv/bin/activate
 dbt build


### PR DESCRIPTION
## Overview
@ChenyuLInx noticed that we were slightly inconsistent in how we refer to the location of Python. This intends to fix that.

## Future
Separately, Chenyu was curious about the 2nd venv activation and he and/or @stu-k intend to do some research why this was necessary.