### PR TITLE
dbt core 1.3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,12 +2,10 @@
 duckcli==0.0.1
 
 # Database adapter
-dbt-duckdb>=1.1.2,<1.2.0
+dbt-duckdb>=1.2.0
 
-# Look for `profiles.yml` in the current working directory to avoid needing to `export DBT_PROFILES_DIR=.`
-git+https://github.com/dbt-labs/dbt-core.git@experiment/local-profiles-1.1.1#subdirectory=core
-git+https://github.com/dbt-labs/dbt-core.git@experiment/local-profiles-1.1.1#subdirectory=plugins/postgres
+# dbt Core 1.3 release candidate
+dbt-core>=1.3.0rc1
 
 # extra features
-
 sqlfluff~=1.2.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-# The only version that works currently
-duckcli==0.0.1
+# 3rd party CLI for DuckDB
+duckcli>=0.2.1
 
 # Database adapter
 dbt-duckdb>=1.2.0


### PR DESCRIPTION
Resolves #20

## This PR
Two things:
- Utilize new [local profiles feature](https://github.com/dbt-labs/dbt-core/issues/5411) of dbt Core 1.3
- Bump the version of [`duckcli`](https://pypi.org/project/duckcli/)

## Up next
Once dbt-duckdb 1.3 and dbt Core 1.3 are released, bump up to those versions within `requirements.txt`:
- Add: `dbt-duckdb>=1.3.0`
- Remove: `dbt-core>=1.3.0rc1` (since it will no longer be necessary)