### PR TITLE
Use alpha version of dbt-duckdb 1.3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@
 duckcli>=0.2.1
 
 # Database adapter
-dbt-duckdb>=1.2.0
+git+https://github.com/dbeatty10/dbt-duckdb.git@dbeatty/bump-version-1.3.0a1#egg=dbt-duckdb
 
 # dbt Core 1.3 release candidate
 dbt-core>=1.3.0rc1


### PR DESCRIPTION
To achieve this:
<img width="580" alt="image" src="https://user-images.githubusercontent.com/44704949/193464993-3aeeca9e-5289-4b9d-9a35-e4b35619582e.png">

Instead of this:
<img width="580" alt="image" src="https://user-images.githubusercontent.com/44704949/193464900-e7a89fb3-3d34-498e-81a0-0d4d1a4d38c3.png">


### Once we can...
We'll bump all requirements up to released versions compatible with dbt Core 1.3 or above.