### PR TITLE
dbt Core 1.3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,10 +2,10 @@
 duckcli>=0.2.1
 
 # Database adapter
-git+https://github.com/dbeatty10/dbt-duckdb.git@dbeatty/bump-version-1.3.0a1#egg=dbt-duckdb
+git+https://github.com/dbeatty10/dbt-duckdb.git@dbeatty/bump-version-1.3.0a2#egg=dbt-duckdb
 
-# dbt Core 1.3 release candidate
-dbt-core>=1.3.0rc1
+# dbt Core 1.3
+dbt-core>=1.3.0
 
 # extra features
 sqlfluff~=1.2.1


### PR DESCRIPTION
Two things:
1. Require dbt Core 1.3.0 or greater
1. Include this in the **faux** 1.3.0a2 for dbt-duckdb:
    - https://github.com/jwills/dbt-duckdb/pull/18