### PR TITLE
update used gh actions ahead of node12 deprecation

### DIFF
--- a/.github/workflows/validate_on_platforms.yml
+++ b/.github/workflows/validate_on_platforms.yml
@@ -11,9 +11,9 @@ jobs:
       name: Validate Getting Started works on macOS
       runs-on: macos-latest
       steps:
-        - uses: actions/checkout@v2
+        - uses: actions/checkout@v3
         - name: Set up Python
-          uses: actions/setup-python@v1
+          uses: actions/setup-python@v4
           with:
             python-version: "3.8.x"
         - name: Full Deploy Commands
@@ -35,9 +35,9 @@ jobs:
       name: Validate Getting Started works on linux
       runs-on: ubuntu-latest
       steps:
-        - uses: actions/checkout@v2
+        - uses: actions/checkout@v3
         - name: Set up Python
-          uses: actions/setup-python@v1
+          uses: actions/setup-python@v4
           with:
             python-version: "3.8.x"
         - name: Full Deploy Commands
@@ -59,9 +59,9 @@ jobs:
       name: Validate Getting Started works on Linux PowerShell Core
       runs-on: ubuntu-latest
       steps:
-        - uses: actions/checkout@v2
+        - uses: actions/checkout@v3
         - name: Set up Python
-          uses: actions/setup-python@v1
+          uses: actions/setup-python@v4
           with:
             python-version: "3.8.x"
         - name: Full Deploy Commands
@@ -83,9 +83,9 @@ jobs:
       name: Validate Getting Started works on Windows PowerShell
       runs-on: windows-latest
       steps:
-        - uses: actions/checkout@v2
+        - uses: actions/checkout@v3
         - name: Set up Python
-          uses: actions/setup-python@v1
+          uses: actions/setup-python@v4
           with:
             python-version: "3.8.x"
         - name: Full Deploy Commands
@@ -107,9 +107,9 @@ jobs:
       name: Validate Getting Started works on Windows cmd.exe
       runs-on: windows-latest
       steps:
-        - uses: actions/checkout@v2
+        - uses: actions/checkout@v3
         - name: Set up Python
-          uses: actions/setup-python@v1
+          uses: actions/setup-python@v4
           with:
             python-version: "3.8.x"
         - name: Full Deploy Commands


### PR DESCRIPTION
Please merge this update today! [node 12 support dropping tomorrow](https://github.blog/changelog/2023-05-04-github-actions-all-actions-will-run-on-node16-instead-of-node12/) and these version updates to Github Actions get ahead of that. Resolves RELENG-144