### PR TITLE
Removed column description from dbt schema yml since it no longer exists in the actual model

### DIFF
--- a/models/schema.yml
+++ b/models/schema.yml
@@ -26,9 +26,6 @@ models:
       - name: number_of_orders
         description: Count of the number of orders a customer has placed
 
-      - name: total_order_amount
-        description: Total value (AUD) of a customer's orders
-
   - name: orders
     description: This table has basic information about orders, as well as some derived facts based on payments
 


### PR DESCRIPTION
The dbt schema yml contained a description for a column called `total_order_amount`. This column no longer exists on the `customers` model, so I cleaned up the `schema.yml` and removed it