### PR TITLE
Change SQLFluff dialect

### DIFF
--- a/.sqlfluff
+++ b/.sqlfluff
@@ -1,3 +1,3 @@
 [sqlfluff]
 
-dialect = ansi
+dialect = duckdb


### PR DESCRIPTION
Change dialect from [ansi](https://docs.sqlfluff.com/en/stable/reference/dialects.html#ansi) to [duckdb](https://docs.sqlfluff.com/en/stable/reference/dialects.html#duckdb).