### PR TITLE
bugfix: updated overview repo link

### DIFF
--- a/models/overview.md
+++ b/models/overview.md
@@ -6,6 +6,6 @@
 
 This [dbt](https://www.getdbt.com/) project is for testing out code.
 
-The source code can be found [here](https://github.com/clrcrl/jaffle_shop).
+The source code can be found [here](https://github.com/dbt-labs/jaffle_shop_duckdb).
 
 {% enddocs %}


### PR DESCRIPTION
The source code link in `models/overview.md` goes to https://github.com/clrcrl/jaffle_shop not https://github.com/dbt-labs/jaffle_shop_duckdb.

Granted, you might prefer it going to https://github.com/dbt-labs/jaffle_shop... up to you.
